### PR TITLE
Pass `wchar_t*` to `std::ifstream::open` to prevent implicit UTF16->ANSI

### DIFF
--- a/src/EnlyzeS7PLib/src/s7p_device_id_info_parser.cpp
+++ b/src/EnlyzeS7PLib/src/s7p_device_id_info_parser.cpp
@@ -24,7 +24,7 @@ static bool
 _FileExists(const std::wstring& wstrFilePath)
 {
     // libc++'s std::filesystem doesn't build for Windows yet, so we have to use this inefficient approach :(
-    std::ifstream f(wstrFilePath);
+    std::ifstream f(wstrFilePath.c_str());
     return f.good();
 }
 
@@ -323,7 +323,7 @@ _ParseResoffAndLinkhrs(std::vector<S7DeviceIdInfo>& DeviceIdInfos, const std::ws
 
     // Open the linkhrs.lnk file.
     std::wstring wstrLinkhrsFilePath = wstrS7PFolderPath + L"\\hrs\\linkhrs.lnk";
-    std::ifstream Linkhrs(wstrLinkhrsFilePath, std::ios::binary);
+    std::ifstream Linkhrs(wstrLinkhrsFilePath.c_str(), std::ios::binary);
     if (!Linkhrs)
     {
         return CS7PError(L"Could not open linkhrs.lnk");


### PR DESCRIPTION
The previously passed `const std::wstring&` was implicitly converted to an `std::filesystem::path`. That library is still considered experimental in the used libc++ release, so it should be avoided outright. Even worse, this version performs an implicit UTF16->ANSI conversion, breaking all efforts of consistent Unicode usage.