### PR TITLE
Invalidate the filename label on resize to prevent a glitch.

### DIFF
--- a/src/CFilePage.cpp
+++ b/src/CFilePage.cpp
@@ -189,8 +189,9 @@ CFilePage::_OnSize()
     RECT rcWindow;
     GetClientRect(m_hWnd, &rcWindow);
 
-    // The text is drawn on most of the window, so invalidate that.
+    // Invalidate all areas with text.
     InvalidateRect(m_hWnd, &rcWindow, FALSE);
+    InvalidateRect(m_hFileName, nullptr, FALSE);
 
     // Move the file icon.
     HDWP hDwp = BeginDeferWindowPos(3);

--- a/src/CMainWindow.cpp
+++ b/src/CMainWindow.cpp
@@ -259,9 +259,7 @@ CMainWindow::_OnDpiChanged(WPARAM wParam, LPARAM lParam)
     m_wCurrentDPI = LOWORD(wParam);
 
     // Redraw the entire window on every DPI change.
-    RECT rcWindow;
-    GetClientRect(m_hWnd, &rcWindow);
-    InvalidateRect(m_hWnd, &rcWindow, FALSE);
+    InvalidateRect(m_hWnd, nullptr, FALSE);
 
     // Recalculate the main GUI font.
     m_lfGuiFont.lfHeight = -ScaleFont(10);


### PR DESCRIPTION
Bug discovered in https://www.sps-forum.de/threads/vorstellung-enlyze-s7-project-explorer-zum-auslesen-einer-s7p-projektdatei-und-exportieren-der-variablenliste-als-csv.109261/post-850813