### PR TITLE
Write a Byte Order Mark (BOM) to the CSV file.

### DIFF
--- a/src/csv_exporter.cpp
+++ b/src/csv_exporter.cpp
@@ -60,11 +60,18 @@ ExportCSV(const std::wstring& wstrCSVFilePath, const std::vector<S7DeviceSymbolI
         return CS7PError(L"CreateFileW failed with error " + std::to_wstring(GetLastError()));
     }
 
-    // Write the CSV output.
+    // Write the BOM to indicate UTF-8 output.
+    const unsigned char ByteOrderMark[] = { 0xEF, 0xBB, 0xBF };
     DWORD cbWritten;
+    if (!WriteFile(hFile.get(), ByteOrderMark, sizeof(ByteOrderMark), &cbWritten, nullptr))
+    {
+        return CS7PError(L"WriteFile failed for the ByteOrderMark with error " + std::to_wstring(GetLastError()));
+    }
+
+    // Write the CSV output.
     if (!WriteFile(hFile.get(), strCSV.c_str(), strCSV.size(), &cbWritten, nullptr))
     {
-        return CS7PError(L"WriteFile failed with error " + std::to_wstring(GetLastError()));
+        return CS7PError(L"WriteFile failed for the CSV content with error " + std::to_wstring(GetLastError()));
     }
 
     return std::monostate();

--- a/src/version.h
+++ b/src/version.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #define APP_MAJOR_VERSION       2
-#define APP_MINOR_VERSION       3
+#define APP_MINOR_VERSION       4
 
 
 // The following macro magic turns arbitrary preprocessor constants into strings.


### PR DESCRIPTION
This indicates UTF-8 and thereby fixes special characters when opening the resulting CSV in Excel. To my knowledge, it has no negative effects in any application that works with CSV files.

Fixes #4