### PR TITLE
Fix address offset bug after STRUCT variables

### DIFF
--- a/src/EnlyzeS7PLib/src/CMc5codeParser.cpp
+++ b/src/EnlyzeS7PLib/src/CMc5codeParser.cpp
@@ -524,6 +524,9 @@ CMc5codeParser::_AddStructVariable(const std::string& strVariableName)
         return *pError;
     }
 
+    // After a STRUCT, align to the next 2-byte boundary for subsequent variables
+    _AlignUp(2 * 8);
+
     return std::monostate();
 }
 


### PR DESCRIPTION
## Problem
Variables defined after STRUCT variables were assigned incorrect memory addresses, causing a systematic offset in the exported symbol addresses.

## Root Cause
After parsing STRUCT variables, the parser did not align the bit address counter to the next 2-byte boundary before continuing with subsequent variables. This caused variables following STRUCTs to be placed at incorrect memory positions.

## Example
- **Before**: `ix_AutomaticStart` got address `DB320:0.3` instead of `DB320:2.0`
<img width="1493" height="499" alt="Screenshot 2025-07-21 092959" src="https://github.com/user-attachments/assets/a420c42c-77a2-4a87-a2af-21e06117db2c" />

- **After**: Correct address `DB320:2.0` as expected in STEP 7
<img width="686" height="604" alt="grafik" src="https://github.com/user-attachments/assets/f98a4c7e-d617-4d3e-8260-f540797cab81" />

## Solution
Added 2-byte alignment (`_AlignUp(2 * 8)`) at the end of `_AddStructVariable()` to ensure subsequent variables start at correct memory boundaries, maintaining STEP 7 memory layout compliance.

## Testing
- Verified with multiple DB files
- Address calculations now match STEP 7 program addresses
- Last variables in DBs have correct addresses (confirming no systematic offset)

## Files Changed
- `src/EnlyzeS7PLib/src/CMc5codeParser.cpp`: Added alignment after STRUCT processing